### PR TITLE
fairseq v1.0およびFSDPへの対応

### DIFF
--- a/fastseq/config.py
+++ b/fastseq/config.py
@@ -23,7 +23,7 @@ MAX_TRANSFORMER_VERSION = '4.12.5'
 
 # supported versions of fairseq
 MIN_FAIRSEQ_VERSION = '0.10.0'
-MAX_FAIRSEQ_VERSION = '0.10.2'
+MAX_FAIRSEQ_VERSION = '1.0.1'
 
 #Set following variable to use Efficient-Lossless Attention
 USE_EL_ATTN = True if os.getenv('USE_EL_ATTN', '0') == '1' else False

--- a/fastseq/optimizer/fairseq/beam_search_optimizer.py
+++ b/fastseq/optimizer/fairseq/beam_search_optimizer.py
@@ -71,7 +71,7 @@ class BeamSearch(BeamSearch):
         return scores_buf, indices_buf, beams_buf
 
 @replace(TransformerEncoder, USE_OPTIMIZED_CACHE_ATTN)
-class TransformerEncoder(TransformerEncoder):
+class TransformerEncoderBase(TransformerEncoder):
     """
     Transformer encoder consisting of *args.encoder_layers* layers. Each layer
     is a :class:`TransformerEncoderLayer`.

--- a/fastseq/optimizer/fairseq/beam_search_optimizer.py
+++ b/fastseq/optimizer/fairseq/beam_search_optimizer.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 from fairseq import utils
-from fairseq.models.transformer import TransformerEncoder, TransformerModel
+from fairseq.models.transformer import TransformerEncoderBase, TransformerModel
 from fairseq.modules.multihead_attention import MultiheadAttention
 from fairseq.search import BeamSearch
 from fairseq.sequence_generator import SequenceGenerator
@@ -70,8 +70,8 @@ class BeamSearch(BeamSearch):
 
         return scores_buf, indices_buf, beams_buf
 
-@replace(TransformerEncoder, USE_OPTIMIZED_CACHE_ATTN)
-class TransformerEncoderBase(TransformerEncoder):
+@replace(TransformerEncoderBase, USE_OPTIMIZED_CACHE_ATTN)
+class TransformerEncoderBase(TransformerEncoderBase):
     """
     Transformer encoder consisting of *args.encoder_layers* layers. Each layer
     is a :class:`TransformerEncoderLayer`.

--- a/fastseq/optimizer/fairseq/el_attention_optimizer.py
+++ b/fastseq/optimizer/fairseq/el_attention_optimizer.py
@@ -9,11 +9,11 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor
 from fairseq import utils
-from fairseq.models.transformer import TransformerEncoder, TransformerDecoder, TransformerModel
+from fairseq.models.transformer import TransformerEncoder, TransformerEncoderBase, TransformerDecoderBase, TransformerModel
 from fairseq.modules.multihead_attention import MultiheadAttention
 from fairseq.sequence_generator import SequenceGenerator, EnsembleModel
 from fairseq.models.fairseq_model import FairseqEncoderDecoderModel
-from fairseq.modules.transformer_layer import TransformerDecoderLayer
+from fairseq.modules.transformer_layer import TransformerDecoderLayerBase
 from fairseq.tasks.fairseq_task import FairseqTask
 from fairseq.data.data_utils import collate_tokens
 from fastseq.utils.api_decorator import replace
@@ -64,8 +64,8 @@ class FairseqTask(FairseqTask):
         for model in models:
             model.transpose_enc_dec_kv_proj()
 
-@replace(TransformerDecoderLayer, USE_EL_ATTN)
-class TransformerDecoderLayer(TransformerDecoderLayer):
+@replace(TransformerDecoderLayerBase, USE_EL_ATTN)
+class TransformerDecoderLayerBase(TransformerDecoderLayerBase):
     def forward(
         self,
         x,
@@ -205,8 +205,8 @@ class TransformerDecoderLayer(TransformerDecoderLayer):
             return x, attn, self_attn_state
         return x, attn, None
 
-@replace(TransformerEncoder, USE_EL_ATTN)
-class TransformerEncoder(TransformerEncoder):
+@replace(TransformerEncoderBase, USE_EL_ATTN)
+class TransformerEncoderBase(TransformerEncoderBase):
     """
     Transformer encoder consisting of *args.encoder_layers* layers. Each layer
     is a :class:`TransformerEncoderLayer`.
@@ -372,8 +372,8 @@ class EnsembleModel(EnsembleModel):
             )
         return new_outs
 
-@replace(TransformerDecoder, USE_EL_ATTN)
-class TransformerDecoder(TransformerDecoder):
+@replace(TransformerDecoderBase, USE_EL_ATTN)
+class TransformerDecoderBase(TransformerDecoderBase):
     """
     Transformer decoder consisting of *args.decoder_layers* layers. Each layer
     is a :class:`TransformerDecoderLayer`.


### PR DESCRIPTION
公式にはfairseq v0.10.2までにしか対応していませんが、fairseq v1.0に暫定的に対応させてみました。
また、おそらくFully Sharded Data Parallel使用時のwrapperのせいだと思いますが、TransformerのEncoderやDecoderがそれぞれBaseモデルで作成されてしまっているため、EL-attentionなどfastseqの機能が使えなかったのをすべてBaseクラスに移すことによって使えるようにしました。

注意点としては一か所だけfairseqに修正が必要です。SequenceGeneratorクラスのインスタンス変数に self.no_repeat_ngram_size を追加してください。0.10.2では存在していましたが、1.0では無くなったものです。

```
diff --git a/fairseq/sequence_generator.py b/fairseq/sequence_generator.py
index e7e02d82..fecea291 100644
--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -91,6 +91,7 @@ class SequenceGenerator(nn.Module):
         self.temperature = temperature
         self.match_source_len = match_source_len

+        self.no_repeat_ngram_size = no_repeat_ngram_size
         if no_repeat_ngram_size > 0:
             self.repeat_ngram_blocker = NGramRepeatBlock(no_repeat_ngram_size)
         else:
```